### PR TITLE
[09-08-17] Library docs updates

### DIFF
--- a/articles/account_management.md
+++ b/articles/account_management.md
@@ -15,8 +15,8 @@ The OAQ application supports several types of **account roles**, each with diffe
 | Account role | Permissions |
 |--|--|
 |Site admin| Can see and manage all organizations, including creating organizations and inviting users to an organization. Currently limited to Harvard library staff. |
-|Organization admin | Can [invite staff to the organization](#inviting-others-to-the-organization), [manage organization users](organizations#managing-organization-users), [edit organization details](organizations#editing-organization-details),  [view author responses](responses#actions-you-can-perform-on-a-response), and [update response statuses](responses#response-status). |
-|Organization staff | Can [view author responses](responses#actions-you-can-perform-on-a-response) and [update response statuses](responses#response-status) |
+|Organization admin | Can [invite staff to the organization](#inviting-others-to-the-organization), [manage organization users](organizations#managing-organization-users), [edit organization details](organizations#editing-organization-details),  [view author responses](responses#actions-you-can-perform-on-a-response), and [update response statuses](responses#response-statuses). |
+|Organization staff | Can [view author responses](responses#actions-you-can-perform-on-a-response) and [update response statuses](responses#response-statuses) |
 
 ## Getting started as an organization admin
 
@@ -26,9 +26,9 @@ Your experience as a library in OAQ begins when the site admin invites the first
 
 Each invited organization admin will receive an email that contains an invitation link. If you receive one of these emails and click the link, you will be taken to a page in OAQ where you can confirm your account and create a password. Note that you can always [change your password](account_management#changing-your-password) later.
 
-## Associating your organization with publishers
+## Partnering with publishers
 
-OAQ facilitates the sharing of questionnaire data between publishers and libraries. As a library, you can associate with specific publishers so that your organization automatically receives responses from those publishers. Only OAQ [site admins](#types-of-account-roles) can set up publisher–library associations, so talk to the site admin who creates your organization about the publishers you wish to work with.
+OAQ facilitates the sharing of questionnaire data between publishers and libraries. As a library, you can partner with specific publishers so that your organization automatically receives responses from those publishers. Only OAQ [site admins](#types-of-account-roles) can set up publisher–library partnerships, so talk to the site admin who creates your organization about the publishers you wish to work with.
 
 ## Inviting others to the organization
 

--- a/articles/responses.md
+++ b/articles/responses.md
@@ -10,7 +10,7 @@ A questionnaire response becomes visible to a library after the publisher has ma
 
 ## Associated questionnaires
 
-When you log into OAQ as a library user, your initial view is the complete set of responses your organization has received across all publishers. The **Questionnaire** column will show the hyperlinked name of each questionnaire associated with the response. If you click one of these hyperlinked names, you will see a list of responses for just that questionnaire.
+When you log into OAQ as a library user, your initial view is the complete set of responses your organization has received across all [partner publishers](account_management#partnering-with-publishers). The **Questionnaire** column will show the hyperlinked name of each questionnaire associated with the response. If you click one of these hyperlinked names, you will see a list of responses for just that questionnaire.
 
 ### Exporting response data
 
@@ -18,14 +18,16 @@ The **Responses for _questionnaire name_** page provides you with the option to 
 
 You can also download individual responses by clicking the **Download** dropdown next to any response and choosing to download either a **CSV** or **PDF** file.
 
-## Response status
+## Response statuses
+
+OAQ workflows depend on updated **response statuses** for the communication of data between publishers and libraries. It's important for libraries to keep response statuses current.
 
 Here’s an explanation of the **Status** dropdown menu options on the **Responses** page:
 
 | Status | Meaning |
 |--|--|
 |Not processed|The library has received the response from the publisher but has not begun processing it.|
-|Library In Progress|The library has received the response from the publisher and begun processing it.|
+|Library In Progress|The library has received the response from the publisher and has begun processing it. Note that this status locks the response for publishers so that answers can't be edited.|
 |Library Complete|The library has received the response from the publisher and finished processing it.|
 
 ## Actions you can perform on a response
@@ -39,7 +41,7 @@ As a library user, OAQ allows you to perform a number of actions on questionnair
 |View ISBN|Shows any ISBN-10 or ISBN-13 that the publisher has associated with the response.|
 |Download|Begins downloading a **CSV** or **PDF** file, depending on the dropdown selection.|
 
-### Status History
+## Status history
 
 You can see the history of library-workflow events that have been performed on each response by clicking **Status History** under **Actions**. Clicking this link will pop up a window that shows:
 


### PR DESCRIPTION
This PR addresses the following feedback from @eslao (sent via email):

> In the "Responses" section: Do we want to be more explicit in our instructions about response status? Workflows may rely on library user keeping each response's status current, so maybe something under "Actions" (I know it's not in the same column, but editing a response status is an action) and/or something in the top section ("Responses")?

I added a couple sentences about the importance of response statuses under "Response statuses." 

> Under "Associated questionnaires": "across all publishers" should be "across all publisher partners" or something to that effect, since a library user's access to responses will be limited by their organization's relationships with publishers.

I edited this sentence as requested.

> I'm also wondering whether the word "association" in the documentation (and in the application) is slightly confusing, since we're using it to describe both the association of responses to questionnaires and the association of library organizations with publisher organizations. Perhaps we could consider more distinct language about questionnaire/response "association" and library/publisher "partnerships".

I changed "associating" to "partnering" throughout. I left the term "association" when it applied to the questionnaire/response relationship.

> we should probably add that the changing a response status to "Library In Progress" locks it for publishers, so that the answers can't be edited.

I added a note about this locking action to the table in "Response statuses."

Note this PR also includes some general editing/cleanup.

/cc @eslao @ColinVanAlstine 